### PR TITLE
Add an example on how to point to a mirror

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -17,6 +17,10 @@ var (
 	ErrNilClient = errors.New("given client is nil")
 )
 
+const (
+	nvdUrl = "https://services.nvd.nist.gov/rest/json/"
+)
+
 // ErrUnexpectedStatus is an error meaning the API call returned a response
 // with an unexpected status. It may occurs when the server is down or the
 // parameters/body is invalid.
@@ -96,7 +100,7 @@ func GetEndp(client HTTPClient, endp string, params, dst any, opts ...Option) er
 	}
 
 	// Build the request
-	req, _ := http.NewRequestWithContext(reqopts.Ctx, http.MethodGet, "https://services.nvd.nist.gov/rest/json/"+endp, nil)
+	req, _ := http.NewRequestWithContext(reqopts.Ctx, http.MethodGet, nvdUrl+endp, nil)
 	if reqopts.APIKey != nil {
 		req.Header.Add("apiKey", *reqopts.APIKey)
 	}

--- a/examples/mirror/README.md
+++ b/examples/mirror/README.md
@@ -1,0 +1,5 @@
+# Mirror
+
+This examples comes in response to [pandatix/nvdapi#100](https://github.com/pandatix/nvdapi/pull/100) where NVD API unavailability was discussed.
+
+The idea is to redirect those API calls to a mirror that would be more available yet match the API schema of the NVD.

--- a/examples/mirror/go.mod
+++ b/examples/mirror/go.mod
@@ -1,0 +1,7 @@
+module github.com/pandatix/nvdapi/examples/mirror
+
+go 1.23.2
+
+require github.com/pandatix/nvdapi v0.6.5
+
+require github.com/gorilla/schema v1.2.1 // indirect

--- a/examples/mirror/go.sum
+++ b/examples/mirror/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/schema v1.2.1 h1:tjDxcmdb+siIqkTNoV+qRH2mjYdr2hHe5MKXbp61ziM=
+github.com/gorilla/schema v1.2.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
+github.com/pandatix/nvdapi v0.6.5 h1:OlSssvh/HTWodPG+BVevtPjWveGLeIE3NFlsahWNGhw=
+github.com/pandatix/nvdapi v0.6.5/go.mod h1:iAC3yGBmh11hwEP3GIyDwT65MGt9au88Z59wSjqtTbQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/mirror/main.go
+++ b/examples/mirror/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/pandatix/nvdapi/common"
+	"github.com/pandatix/nvdapi/v2"
+)
+
+const (
+	cveid = "CVE-2021-28378"
+)
+
+func main() {
+	// Create a mirror client to redirect request elsewhere
+	mc, err := NewMirrorClient(&http.Client{}, "https://nvd.mirror.lan")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a NVD client
+	cli, _ := nvdapi.NewNVDClient(mc, "<API_KEY>")
+
+	// Make API calls to the mirror (or a proxy)
+	res, err := nvdapi.GetCVEs(cli, nvdapi.GetCVEsParams{
+		CVEID: ptr(cveid),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("[%s]\n%s\n", cveid, res.Vulnerabilities[0].CVE.Descriptions[0].Value)
+}
+
+// NewMirrorClient creates a *MirrorClient.
+func NewMirrorClient(sub common.HTTPClient, baseUrl string) (*MirrorClient, error) {
+	if _, err := url.Parse(baseUrl); err != nil {
+		return nil, err
+	}
+	if sub == nil {
+		return nil, common.ErrNilClient
+	}
+	return &MirrorClient{
+		sub:     sub,
+		baseUrl: baseUrl,
+	}, nil
+}
+
+// MirrorClient is a common.HTTPClient implementation to redirect
+// requests to a mirror.
+type MirrorClient struct {
+	sub     common.HTTPClient
+	baseUrl string
+}
+
+var _ common.HTTPClient = (*MirrorClient)(nil)
+
+func (cli *MirrorClient) Do(req *http.Request) (*http.Response, error) {
+	// Redirect to a custom base URL, don't forget to happend
+	// the path and the query
+	nurl, err := url.Parse(fmt.Sprintf("%s%s?%s", cli.baseUrl, req.URL.Path, req.URL.RawQuery))
+	if err != nil {
+		return nil, err
+	}
+	req.URL = nurl
+
+	// Pass to execute by underlying common.HTTPClient.
+	return cli.sub.Do(req)
+}
+
+func ptr[T any](t T) *T {
+	return &t
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pandatix/nvdapi
 
-go 1.22.1
+go 1.23.2
 
 require (
 	github.com/gorilla/schema v1.4.1

--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.23.2
+
+use (
+	.
+	./examples/mirror
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,1 @@
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=


### PR DESCRIPTION
This PR comes in response of discussion in #100.

I don't think the implementation should break its isolation thus have a high coupling with its dependents. Such behavior should be implemented around the API, ideally possible by passing a `common.HTTPClient` to the NVD Client.

Ping @iansltx :)

<details>
Closes #100.
</details>